### PR TITLE
Upgrade gulp-less to support Node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "chalk": "^0.5.1",
     "del": "^1.1.1",
     "gulp": "^3.8.10",
-    "gulp-less": "^2.0.1",
+    "gulp-less": "^3.0.2",
     "gulp-plumber": "^0.6.6",
     "gulp-shell": "^0.2.11",
     "gulp-util": "^3.0.2",


### PR DESCRIPTION
Fixed in issue: https://github.com/plus3network/gulp-less/issues/140
