### PR TITLE
No global gulp

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,19 +39,6 @@ try {
 		'Please add gulp ^' + packageGulpVersion + ' to your package.json, npm install and try again.'
 	);
 }
-try {
-	// Check to make sure the local gulp and the project gulp match.
-	var packageGulpVersion = require('./node_modules/gulp/package.json').version;
-	if (semver.satisfies(projectGulpVersion, '^' + packageGulpVersion)) {
-		fatal(
-			'You do not have the correct version of Gulp installed in your project.',
-			'Please add gulp ^' + packageGulpVersion + ' to your package.json, npm install and try again.'
-		);
-	}
-} catch(e) {
-	// Assume gulp has been loaded from ../node_modules and it matches the requirements.
-}
-
 
 /**
  * This package exports a function that binds tasks to a gulp instance

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var brfs = require('brfs');
 var browserify = require('browserify');
 var chalk = require('chalk');
 var del = require('del');
-var gulp = require('gulp');
 var gutil = require('gulp-util');
 var less = require('gulp-less');
 var merge = require('merge-stream');
@@ -11,34 +10,6 @@ var plumber = require('gulp-plumber');
 var shell = require('gulp-shell');
 var source = require('vinyl-source-stream');
 var watchify = require('watchify');
-
-
-/**
- * Check that a compatible version of gulp is available in the project
- */
-
-function fatal(err) {
-	var msg = '\n\n';
-	if (Array.isArray(err)) {
-		err.forEach(function(i) {
-			msg += i + '\n\n';
-		});
-	} else {
-		msg += (err || 'Fatal error, bailing.') + '\n\n';
-	}
-	console.log(msg);
-	process.exit(1);
-}
-
-try {
-	var projectGulpVersion = require(module.parent.paths[0] + '/gulp/package.json').version;
-} catch(e) {
-	// If we can't find gulp in the parent project, it's a fatal problem.
-	fatal(
-		'You do not seem to have Gulp installed in your project.',
-		'Please add gulp ^' + packageGulpVersion + ' to your package.json, npm install and try again.'
-	);
-}
 
 /**
  * This package exports a function that binds tasks to a gulp instance


### PR DESCRIPTION
Global gulp is an anti-pattern.

This file is only ever run in a gulp context, `gulp` will [now] immediately throw as `undefined` when run.  

`npm` will throw a warning if `gulp` is missing as a `peerDependency`.
