### PR TITLE
rm cordova prepare task

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ var del = require('del');
 var gutil = require('gulp-util');
 var less = require('gulp-less');
 var merge = require('merge-stream');
-var plumber = require('gulp-plumber');
-var shell = require('gulp-shell');
 var source = require('vinyl-source-stream');
 var watchify = require('watchify');
 var xtend = require('xtend');
@@ -121,9 +119,4 @@ module.exports = function (gulp) {
 	});
 
 	gulp.task('dev', ['serve', 'watch']);
-
-	// Cordova
-	gulp.task('prepare', ['build'], function () {
-		return gulp.src('').pipe(plumber()).pipe(shell(['cordova prepare'], { cwd: __dirname }));
-	});
 };

--- a/package.json
+++ b/package.json
@@ -20,8 +20,6 @@
     "del": "^1.2.0",
     "gulp-connect": "^2.2.0",
     "gulp-less": "^3.0.3",
-    "gulp-plumber": "^1.0.1",
-    "gulp-shell": "^0.4.2",
     "gulp-util": "^3.0.5",
     "merge-stream": "^0.1.7",
     "vinyl-source-stream": "^1.1.0",


### PR DESCRIPTION
IMHO, `cordova` has no business being here.
There are so several `cordova` steps you are going to have to take to even get to this point,  why is only 1 of them automated?

It rarely integrates with my work flow anyway,  as I will just `cordova build` or `cordova run`,  with `cordova prepare` only ever being done on that initial setup.

Its also not installed as a `devDependency`, or even `peerDependency`,  so,  there is that too.
